### PR TITLE
fix: ignore empty string result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# Debugging Results Output File
+/Results.txt

--- a/word-muncher/WordProcessor.cs
+++ b/word-muncher/WordProcessor.cs
@@ -26,7 +26,7 @@ namespace word_muncher
             ContentList = contents
                 .Split(Delimitters, StringSplitOptions.RemoveEmptyEntries)
                 .Select(s => s.Trim().ToLowerInvariant().StemWord())
-                .Where(s => !StopWords.Any(stopWord => stopWord.Equals(s, StringComparison.OrdinalIgnoreCase)));
+                .Where(s => !string.IsNullOrEmpty(s) && !StopWords.Any(stopWord => stopWord.Equals(s, StringComparison.OrdinalIgnoreCase)));
 
             foreach (string word in ContentList)
             {


### PR DESCRIPTION
Fixed bug where empty string was being counted as a valid word.  Added the Results.txt file to gitignore list.